### PR TITLE
update pacman.conf and cjk support

### DIFF
--- a/packages.x86_64
+++ b/packages.x86_64
@@ -132,3 +132,8 @@ gnome-text-editor
 eog
 nano
 xorg # VMSVGA support (Virtualbox, VMware)
+# CJK Support
+noto-fonts
+noto-fonts-cjk
+noto-fonts-extra
+noto-fonts-emoji

--- a/pacman.conf
+++ b/pacman.conf
@@ -22,7 +22,7 @@ HoldPkg     = pacman glibc
 Architecture = auto
 
 # Pacman won't upgrade packages listed in IgnorePkg and members of IgnoreGroup
-#IgnorePkg   =
+IgnorePkg   = fakeroot
 #IgnoreGroup =
 
 #NoUpgrade   =
@@ -30,9 +30,8 @@ Architecture = auto
 
 # Misc options
 #UseSyslog
-#Color
+Color
 #NoProgressBar
-# We cannot check disk space from within a chroot environment
 #CheckSpace
 #VerbosePkgLists
 ParallelDownloads = 5
@@ -77,12 +76,6 @@ LocalFileSigLevel = Optional
 Include = /etc/pacman.d/mirrorlist
 
 [extra]
-Include = /etc/pacman.d/mirrorlist
-
-#[community-testing]
-#Include = /etc/pacman.d/mirrorlist
-
-[community]
 Include = /etc/pacman.d/mirrorlist
 
 # If you want to run 32 bit applications on your x86_64 system,

--- a/pacman.conf
+++ b/pacman.conf
@@ -22,7 +22,7 @@ HoldPkg     = pacman glibc
 Architecture = auto
 
 # Pacman won't upgrade packages listed in IgnorePkg and members of IgnoreGroup
-IgnorePkg   = fakeroot
+#IgnorePkg   =
 #IgnoreGroup =
 
 #NoUpgrade   =
@@ -30,11 +30,14 @@ IgnorePkg   = fakeroot
 
 # Misc options
 #UseSyslog
-Color
+#Color
 #NoProgressBar
+# We cannot check disk space from within a chroot environment
 #CheckSpace
 #VerbosePkgLists
 ParallelDownloads = 5
+#DownloadUser = alpm
+#DisableSandbox
 
 # By default, pacman accepts packages signed by keys that its local keyring
 # trusts (see pacman-key and its man page), as well as unsigned packages.
@@ -69,11 +72,14 @@ LocalFileSigLevel = Optional
 # repo name header and Include lines. You can add preferred servers immediately
 # after the header, and they will be used before the default mirrors.
 
-#[testing]
+#[core-testing]
 #Include = /etc/pacman.d/mirrorlist
 
 [core]
 Include = /etc/pacman.d/mirrorlist
+
+#[extra-testing]
+#Include = /etc/pacman.d/mirrorlist
 
 [extra]
 Include = /etc/pacman.d/mirrorlist


### PR DESCRIPTION
Use https://gitlab.archlinux.org/archlinux/archiso/-/blob/master/configs/releng/pacman.conf to replace the outdated pacman.conf file and add cjk text support